### PR TITLE
Use provived encoding to open nb files

### DIFF
--- a/pipreqsnb/pipreqsnb.py
+++ b/pipreqsnb/pipreqsnb.py
@@ -113,13 +113,20 @@ def main():
         temp_path = '{}/{}/'.format(input_path, temp_path_folder_name)
     temp_file = '{}/{}'.format(temp_path, temp_file_name)
     imports = []
+    open_file_args = {}
+    if args.encoding is not None:
+        open_file_args['encoding'] = args.encoding
     for nb_file in ipynb_files:
-        nb = json.load(open(nb_file, 'r'))
-        for cell in nb['cells']:
-            if cell['cell_type'] == 'code':
-                valid_lines = clean_invalid_lines_from_list_of_lines(cell['source'])
-                source = ''.join(valid_lines)
-                imports += get_import_string_from_source(source)
+        nb = json.load(open(nb_file, 'r', **open_file_args))
+        try:
+            for n_cell, cell in enumerate(nb['cells']):
+                if cell['cell_type'] == 'code':
+                    valid_lines = clean_invalid_lines_from_list_of_lines(cell['source'])
+                    source = ''.join(valid_lines)
+                    imports += get_import_string_from_source(source)
+        except Exception as e:
+            print("Exception occurred while working on file {}, cell {}/{}".format(nb_file, n_cell + 1, len(nb['cells'])))
+            raise e
 
     # hack to remove the indents if imports are inside functions
     imports = [i.lstrip() for i in imports]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='pipreqsnb',
-    version='0.2.2',
+    version='0.2.3',
     description='Pipreqs with jupyter notebook support',
     url='https://github.com/ivanlen/pipreqsnb',
     author='Ivan Lengyel',


### PR DESCRIPTION
I added the user provided encoding (if it exists) to the `(open(nb_file, 'r')` function call because I was getting encoding errors while trying to use this package with my jupyter notebooks.

![erro-pipreqsnb](https://user-images.githubusercontent.com/5862030/98247471-6cea3600-1f52-11eb-817a-f31c367c3bf3.png)

I also added exception handling while iterating over the files so we know what file and cell caused an error to happen. Let me know if you prefer that I create another pull request for this feature.