### PR TITLE
Add the license file to package-source

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     long_description=readme,
     license='MIT License',
+    license_files=("LICENSE.txt",),
     packages=setuptools.find_packages(),
     install_requires=['pipreqs'],
     zip_safe=False)


### PR DESCRIPTION
The PyPI release (source file: `tar.gz`) does not include any license file. This PR fixes that.

## The Problem

![pipreqsnb-pypi-source](https://user-images.githubusercontent.com/10201242/147832984-6af7427d-83d5-491b-898b-9b6474112c99.png)

## The Fix

Update `setup.py`.

![image](https://user-images.githubusercontent.com/10201242/147833089-ceca1e71-7825-401a-ba2c-8105cdd3d5e2.png)