### PR TITLE
Add mode option

### DIFF
--- a/pipreqsnb/pipreqsnb.py
+++ b/pipreqsnb/pipreqsnb.py
@@ -7,7 +7,7 @@ import shutil
 import json
 import os
 
-pipreqs_options_store = ['use-local', 'debug', 'print', 'force', 'no-pin']
+pipreqs_options_store = ['use-local', 'debug', 'print', 'force', 'mode']
 pipreqs_options_args = ['pypi-server', 'proxy', 'ignore', 'encoding', 'savepath', 'diff', 'clean']
 
 

--- a/pipreqsnb/pipreqsnb.py
+++ b/pipreqsnb/pipreqsnb.py
@@ -7,8 +7,8 @@ import shutil
 import json
 import os
 
-pipreqs_options_store = ['use-local', 'debug', 'print', 'force', 'mode']
-pipreqs_options_args = ['pypi-server', 'proxy', 'ignore', 'encoding', 'savepath', 'diff', 'clean']
+pipreqs_options_store = ['use-local', 'debug', 'print', 'force']
+pipreqs_options_args = ['pypi-server', 'proxy', 'ignore', 'encoding', 'savepath', 'diff', 'clean','mode']
 
 
 def clean_invalid_lines_from_list_of_lines(list_of_lines):


### PR DESCRIPTION
this is to help fix latest comments to #18 
`pipreqs` now uses `--mode no-pin` as option rather than `--no-pin`